### PR TITLE
Add CI workflow for continuous integration and linting/formatting checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: ci
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+      - run: bun install
+      - run: bun test
+
+  lint-format:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+      - run: bun install
+      - run: bun lint:fix
+      - run: bun format
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5

--- a/app/utils/asserts/assertHasAtLeast.spec.ts
+++ b/app/utils/asserts/assertHasAtLeast.spec.ts
@@ -1,4 +1,4 @@
-import { expect, describe, it } from 'bun:test'
+import { describe, expect, it } from 'bun:test'
 import { assertHasAtLeast } from './assertHasAtLeast'
 
 describe('assertHasAtLeast', () => {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
+    "lint": "biome check ./app",
+    "lint:fix": "biome check --write ./app",
     "format": "biome format --write ./app"
   },
   "dependencies": {


### PR DESCRIPTION
This pull request adds a CI workflow for continuous integration and linting/formatting checks. The workflow includes two jobs: "test" and "lint-format". The "test" job runs the tests using the "bun" package manager, while the "lint-format" job performs linting and formatting checks using the same package manager. The CI workflow is triggered on push to the main branch and on various pull request events.