### PR TITLE
Add assertDefined and update assertHasAtLeast

### DIFF
--- a/app/composables/assertDefined.spec.ts
+++ b/app/composables/assertDefined.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'bun:test'
+import { computed, ref } from 'vue'
+import { assertDefined } from './assertDefined'
+
+describe('assertDefined', () => {
+	it('should support refs', () => {
+		const definedRef = ref('test')
+		const undefinedRef = ref(undefined)
+		const nullRef = ref(null)
+
+		expect(() => assertDefined(definedRef)).not.toThrow()
+		expect(() => assertDefined(undefinedRef)).toThrow()
+		expect(() => assertDefined(nullRef)).toThrow()
+	})
+
+	it('should support computed refs', () => {
+		const definedComputed = computed(() => 'test')
+		const undefinedComputed = computed(() => undefined)
+		const nullComputed = computed(() => null)
+
+		expect(() => assertDefined(definedComputed)).not.toThrow()
+		expect(() => assertDefined(undefinedComputed)).toThrow()
+		expect(() => assertDefined(nullComputed)).toThrow()
+	})
+
+	it('should support getters', () => {
+		const definedGetter = () => 'test'
+		const undefinedGetter = () => undefined
+		const nullGetter = () => null
+
+		expect(() => assertDefined(definedGetter)).not.toThrow()
+		expect(() => assertDefined(undefinedGetter)).toThrow()
+		expect(() => assertDefined(nullGetter)).toThrow()
+	})
+
+	it('should support values', () => {
+		const definedValue = 'test'
+		const undefinedValue = undefined
+		const nullValue = null
+
+		expect(() => assertDefined(definedValue)).not.toThrow()
+		expect(() => assertDefined(undefinedValue)).toThrow()
+		expect(() => assertDefined(nullValue)).toThrow()
+	})
+
+	it('should throw specified error message', () => {
+		const undefinedValue = undefined
+		const message = 'wtf'
+
+		expect(() => assertDefined(undefinedValue, { message })).toThrow(message)
+	})
+})

--- a/app/composables/assertDefined.ts
+++ b/app/composables/assertDefined.ts
@@ -1,0 +1,37 @@
+import { toValue } from 'vue'
+
+/**
+ * Guards that a value is not `null` or `undefined`.
+ * @param v The value to check.
+ * @param options Options. See {@link Options}.
+ * @example
+ * const video = ref<HTMLVideoElement | null>(null)
+ *
+ * function play() {
+ *   assertDefined(video) // Throws an error if `video.value` is `null` or `undefined`.
+ *
+ *   video.value.play()
+ * }
+ */
+export function assertDefined<T>(
+	v: Ref<T>,
+	options?: Options,
+): asserts v is Ref<Exclude<T, null | undefined>>
+
+export function assertDefined<T>(
+	v: ComputedRef<T>,
+	options?: Options,
+): asserts v is ComputedRef<Exclude<T, null | undefined>>
+
+export function assertDefined<T>(v: T, options?: Options): asserts v is Exclude<T, null | undefined>
+
+export function assertDefined<T>(v: Ref<T>, options: Options = {}): void {
+	const { message = 'Value is undefined or null' } = options
+
+	if (toValue(v) == null) throw new Error(message)
+}
+
+type Options = {
+	/** An error message to throw if the assertion fails. */
+	message?: string
+}

--- a/app/utils/asserts/assertHasAtLeast.spec.ts
+++ b/app/utils/asserts/assertHasAtLeast.spec.ts
@@ -5,11 +5,11 @@ describe('assertHasAtLeast', () => {
 	const array: number[] = [1, 2, 3, 4, 5]
 
 	it.each([1, 2, 3, 4, 5] as const)('should not throw an error', (value) => {
-		expect(() => assertHasAtLeast(array, value, 'wtf')).not.toThrow()
+		expect(() => assertHasAtLeast(array, value, { message: 'wtf' })).not.toThrow()
 	})
 
 	it.each([6, 7, 8, 9, 10] as const)('should throw an error', (value) => {
-		expect(() => assertHasAtLeast(array, value, 'wtf')).toThrow('wtf')
+		expect(() => assertHasAtLeast(array, value, { message: 'wtf' })).toThrow('wtf')
 	})
 
 	it('should throw an error with the default message when the given message is not specified', () => {

--- a/app/utils/asserts/assertHasAtLeast.ts
+++ b/app/utils/asserts/assertHasAtLeast.ts
@@ -2,17 +2,25 @@
  * Asserts that an array has at least a certain number of elements.
  * @param value The array to check.
  * @param n The minimum number of elements required.
- * @param [msg] An optional error message to throw if the assertion fails.
+ * @param options An optional object of options. See {@link Options} for more information.
  * @throws If the array has less than N elements and no error message is provided.
  */
 export function assertHasAtLeast<T, N extends NumberRange<1, 10>>(
 	value: T[],
 	n: N,
-	msg?: string,
+	options: Options = {},
 ): asserts value is ArrayAtLeast<T, N> {
-	if (value.length < n)
-		throw new Error(
-			msg ??
-				`Expected the array to have at least ${n} elements, but it has ${value.length} elements.`,
-		)
+	const {
+		message = `Expected the array to have at least ${n} elements, but it has ${value.length} elements.`,
+	} = options
+
+	if (value.length < n) throw new Error(message)
+}
+
+/**
+ * Options for the {@link assertHasAtLeast} function.
+ */
+type Options = {
+	/** An optional error message to throw if the assertion fails. */
+	message?: string
 }


### PR DESCRIPTION
This pull request adds a new function called `assertDefined` and updates the existing function `assertHasAtLeast`. The `assertDefined` function is used to guard against values that are `null` or `undefined`, while the `assertHasAtLeast` function now accepts an optional error message as an argument. These changes improve the functionality and usability of the codebase.